### PR TITLE
Fix admin cookie retrieval for Next.js 15

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -21,7 +21,8 @@ export default async function AdminPage() {
     );
   }
 
-  const cookieToken = cookies().get(ADMIN_COOKIE)?.value;
+  const cookieStore = await cookies();
+  const cookieToken = cookieStore.get(ADMIN_COOKIE)?.value;
   const isAuthorized = cookieToken === token;
 
   if (!isAuthorized) {


### PR DESCRIPTION
## Summary
- use the awaited cookies API before reading the admin session cookie

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd8015ef048321b882013647270aa8